### PR TITLE
Mod

### DIFF
--- a/C prototipo/integracion Pi/.gitignore
+++ b/C prototipo/integracion Pi/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/C prototipo/integracion Pi/.vscode/extensions.json
+++ b/C prototipo/integracion Pi/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/C prototipo/integracion Pi/include/README
+++ b/C prototipo/integracion Pi/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/C prototipo/integracion Pi/lib/README
+++ b/C prototipo/integracion Pi/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/C prototipo/integracion Pi/platformio.ini
+++ b/C prototipo/integracion Pi/platformio.ini
@@ -1,0 +1,15 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_deps = bodmer/TFT_eSPI@^2.5.43

--- a/C prototipo/integracion Pi/src/main.cpp
+++ b/C prototipo/integracion Pi/src/main.cpp
@@ -1,0 +1,228 @@
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <esp_sleep.h>
+#include <EEPROM.h>
+#include <HTTPClient.h>
+#include <TFT_eSPI.h> 
+#include <SPI.h>
+
+// WiFi Configuration
+const char* ssid = "Xiaomi";
+const char* password = "12345678";
+
+// Pin definitions for ESP32 WROOM
+const int CAPACITIVO = 34;        // GPIO 34 - Touch 
+const int CNY70 = 36;             // GPIO 36 
+const int LED_ROJO = 26;          // GPIO 26
+const int LED_VERDE = 27;         // GPIO 27
+
+// Display SPI pins for ESP32 WROOM
+#define TFT_MISO 19
+#define TFT_MOSI 23
+#define TFT_SCLK 18
+#define TFT_CS   5  
+#define TFT_DC   2
+#define TFT_RST  4
+
+// EEPROM 
+const int EEPROM_SIZE = 512; 
+int writeIndex = 0;
+
+// Timing and state variables
+unsigned long lastReadingTime = 0;
+const unsigned long LECTURA_TIMEOUT = 10000;    // 10 seg
+const unsigned long LED_BLINK_INTERVAL = 500;   // LED blink interval
+unsigned long lastBlinkTime = 0;
+bool leyendo = false;
+unsigned long tiempoInicio = 0;
+bool lecturaCompletada = false;
+
+// ADC Config
+const int ADC_RESOLUTION = 4095;    // ESP32 has 12-bit ADC
+const float ADC_VOLTAGE = 3.3;      // Reference voltage
+
+// TFT Disp
+TFT_eSPI tft = TFT_eSPI();
+
+// EEPROM
+struct RegistroEstado {
+    bool enviado;      // I
+    unsigned long timestamp;
+    unsigned short valor;
+};
+
+void setup() {
+    Serial.begin(115200);
+    
+    //  ADC
+    analogReadResolution(12);    
+    analogSetAttenuation(ADC_11db); 
+    
+    // Init EEPROM
+    if (!EEPROM.begin(EEPROM_SIZE)) {
+        Serial.println("Failed to initialize EEPROM");
+        while (1);
+    }
+    
+    
+    pinMode(CNY70, INPUT);
+    pinMode(LED_ROJO, OUTPUT);
+    pinMode(LED_VERDE, OUTPUT);
+    
+    // display
+    tft.init();
+    tft.setRotation(1);
+    tft.fillScreen(TFT_BLACK);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    
+    //  LED 
+    digitalWrite(LED_ROJO, LOW);
+    digitalWrite(LED_VERDE, LOW);
+    
+    //WiFi
+    connectWiFi();
+}
+
+float leerCNY70() {
+    const int NUMERO_MUESTRAS = 10;
+    long suma = 0;
+    
+    for(int i = 0; i < NUMERO_MUESTRAS; i++) {
+        suma += analogRead(CNY70);
+        delay(10);
+    }
+    
+    float promedio = suma / NUMERO_MUESTRAS;
+    float voltaje = (promedio * ADC_VOLTAGE) / ADC_RESOLUTION;
+    
+    Serial.printf("Valor ADC: %.2f, Voltaje: %.2f V\n", promedio, voltaje);
+    return voltaje;
+}
+
+bool detectarContacto() {
+    int touchValue = touchRead(CAPACITIVO);
+    return touchValue < 40; 
+}
+
+
+void loop() {
+    unsigned long currentTime = millis();
+    bool contactoDetectado = detectarContacto();
+    
+    Serial.printf("Touch Value: %d, Contacto: %s\n", touchRead(CAPACITIVO), contactoDetectado ? "SI" : "NO");
+    
+    if (contactoDetectado && !leyendo) {
+        leyendo = true;
+        tiempoInicio = currentTime;
+        lecturaCompletada = false;
+        digitalWrite(LED_ROJO, LOW);
+        Serial.println("Contacto detectado - Iniciando lectura");
+    }
+    
+    if (leyendo) {
+        if (!contactoDetectado) {
+            leyendo = false;
+            digitalWrite(LED_VERDE, LOW);
+            digitalWrite(LED_ROJO, HIGH);
+            Serial.println("Contacto perdido durante lectura");
+            return;
+        }
+        
+        if (currentTime - lastBlinkTime >= LED_BLINK_INTERVAL) {
+            digitalWrite(LED_VERDE, !digitalRead(LED_VERDE));
+            lastBlinkTime = currentTime;
+            float valorActual = leerCNY70();
+            Serial.printf("Lectura en curso: %.2f V\n", valorActual);
+        }
+        
+        if (currentTime - tiempoInicio >= LECTURA_TIMEOUT && !lecturaCompletada) {
+            lecturaCompletada = true;
+            digitalWrite(LED_VERDE, HIGH);
+            
+            float valorFinal = leerCNY70();
+            guardarMedicionEnEEPROM(currentTime, valorFinal * 100);
+            mostrarLectura(valorFinal);
+            
+            if (WiFi.status() == WL_CONNECTED) {
+                enviarDatosAlServidor();
+            } else {
+                Serial.println("Sin conexión WiFi - Datos guardados en EEPROM");
+                connectWiFi();
+            }
+            
+            delay(3000);
+            entrarModoBajoConsumo();
+        }
+    } else {
+        digitalWrite(LED_VERDE, LOW);
+        if (currentTime - lastBlinkTime >= LED_BLINK_INTERVAL) {
+            digitalWrite(LED_ROJO, !digitalRead(LED_ROJO));
+            lastBlinkTime = currentTime;
+        }
+    }
+}
+
+void guardarMedicionEnEEPROM(unsigned long timestamp, int valor) {
+    if (writeIndex >= EEPROM_SIZE - sizeof(RegistroEstado)) {
+        writeIndex = 0;  
+    }
+    
+    RegistroEstado registro;
+    registro.enviado = false;
+    registro.timestamp = timestamp;
+    registro.valor = valor;
+    
+    EEPROM.put(writeIndex, registro);
+    
+    if (EEPROM.commit()) {
+        Serial.println("Datos guardados en EEPROM");
+        writeIndex += sizeof(RegistroEstado);
+    } else {
+        Serial.println("Error al guardar en EEPROM");
+    }
+}
+
+void enviarDatosAlServidor() {
+    if (WiFi.status() != WL_CONNECTED) {
+        Serial.println("Sin conexión WiFi");
+        return;
+    }
+
+    HTTPClient http;
+    http.begin("http://192.168.0.10:5000/api/mediciones");
+    http.addHeader("Content-Type", "application/json");
+    
+    int registrosEnviados = 0;
+    
+    for (int i = 0; i < writeIndex; i += sizeof(RegistroEstado)) {
+        RegistroEstado registro;
+        EEPROM.get(i, registro);
+        
+        if (!registro.enviado) {
+            String jsonData = "{\"timestamp\":" + String(registro.timestamp) + 
+                            ",\"valor\":" + String(registro.valor/100.0, 2) + "}";
+            
+            int httpCode = http.POST(jsonData);
+            
+            if (httpCode == HTTP_CODE_OK || httpCode == HTTP_CODE_CREATED) {
+                registro.enviado = true;
+                EEPROM.put(i, registro);
+                registrosEnviados++;
+                Serial.printf("Registro enviado exitosamente. Timestamp: %lu\n", registro.timestamp);
+            } else {
+                Serial.printf("Error al enviar registro. HTTP code: %d\n", httpCode);
+                break;
+            }
+            delay(100);
+        }
+    }
+    
+    http.end();
+    
+    if (registrosEnviados > 0 && EEPROM.commit()) {
+        Serial.printf("Se marcaron %d registros como enviados\n", registrosEnviados);
+    } else {
+        Serial.println("Error al actualizar estado de registros en EEPROM");
+    }
+}

--- a/C prototipo/integracion Pi/src/main.cpp
+++ b/C prototipo/integracion Pi/src/main.cpp
@@ -1,4 +1,3 @@
-
 #include <Arduino.h>
 #include <WiFi.h>
 #include <esp_sleep.h>
@@ -7,17 +6,17 @@
 #include <TFT_eSPI.h> 
 #include <SPI.h>
 
-// WiFi Configuration
+// Configuración WiFi
 const char* ssid = "Xiaomi";
 const char* password = "12345678";
 
-// Pin definitions for ESP32 WROOM
-const int CAPACITIVO = 34;        // GPIO 34 - Touch 
-const int CNY70 = 36;             // GPIO 36 
-const int LED_ROJO = 26;          // GPIO 26
-const int LED_VERDE = 27;         // GPIO 27
+// Definición de pines para ESP32 WROOM
+const int CAPACITIVO = 34;        // GPIO 34 - Sensor Touch 
+const int CNY70 = 36;             // GPIO 36 - Sensor CNY70
+const int LED_ROJO = 26;          // GPIO 26 - LED Indicador
+const int LED_VERDE = 27;         // GPIO 27 - LED Indicador
 
-// Display SPI pins for ESP32 WROOM
+// Pines SPI para pantalla TFT en ESP32 WROOM
 #define TFT_MISO 19
 #define TFT_MOSI 23
 #define TFT_SCLK 18
@@ -25,65 +24,88 @@ const int LED_VERDE = 27;         // GPIO 27
 #define TFT_DC   2
 #define TFT_RST  4
 
-// EEPROM 
+// Configuración EEPROM 
 const int EEPROM_SIZE = 512; 
 int writeIndex = 0;
 
-// Timing and state variables
+// Variables de tiempo y estado
 unsigned long lastReadingTime = 0;
-const unsigned long LECTURA_TIMEOUT = 10000;    // 10 seg
-const unsigned long LED_BLINK_INTERVAL = 500;   // LED blink interval
+const unsigned long LECTURA_TIMEOUT = 10000;    // 10 segundos timeout
+const unsigned long LED_BLINK_INTERVAL = 500;   // Intervalo parpadeo LED
 unsigned long lastBlinkTime = 0;
 bool leyendo = false;
 unsigned long tiempoInicio = 0;
 bool lecturaCompletada = false;
 
-// ADC Config
-const int ADC_RESOLUTION = 4095;    // ESP32 has 12-bit ADC
-const float ADC_VOLTAGE = 3.3;      // Reference voltage
+// Configuración ADC
+const int ADC_RESOLUTION = 4095;    // ESP32 tiene ADC de 12 bits
+const float ADC_VOLTAGE = 3.3;      // Voltaje de referencia
 
-// TFT Disp
+// Objeto pantalla TFT
 TFT_eSPI tft = TFT_eSPI();
 
-// EEPROM
+// Estructura para almacenar datos en EEPROM
 struct RegistroEstado {
-    bool enviado;      // I
-    unsigned long timestamp;
-    unsigned short valor;
+    bool enviado;                // Indicador si fue enviado
+    unsigned long timestamp;     // Marca de tiempo
+    unsigned short valor;        // Valor medido
 };
 
+// Función de inicialización
 void setup() {
     Serial.begin(115200);
     
-    //  ADC
+    // Configuración ADC
     analogReadResolution(12);    
     analogSetAttenuation(ADC_11db); 
     
-    // Init EEPROM
+    // Inicializar EEPROM
     if (!EEPROM.begin(EEPROM_SIZE)) {
-        Serial.println("Failed to initialize EEPROM");
+        Serial.println("Error al inicializar EEPROM");
         while (1);
     }
     
-    
+    // Configurar pines
     pinMode(CNY70, INPUT);
     pinMode(LED_ROJO, OUTPUT);
     pinMode(LED_VERDE, OUTPUT);
     
-    // display
+    // Inicializar pantalla
     tft.init();
     tft.setRotation(1);
     tft.fillScreen(TFT_BLACK);
     tft.setTextColor(TFT_WHITE, TFT_BLACK);
     
-    //  LED 
+    // Estado inicial LEDs
     digitalWrite(LED_ROJO, LOW);
     digitalWrite(LED_VERDE, LOW);
     
-    //WiFi
+    // Conectar WiFi
     connectWiFi();
 }
 
+// Función para conectar WiFi
+void connectWiFi() {
+    Serial.println("Conectando a WiFi...");
+    WiFi.begin(ssid, password);
+    
+    int intentos = 0;
+    while (WiFi.status() != WL_CONNECTED && intentos < 40) {
+        delay(500);
+        Serial.print(".");
+        intentos++;
+    }
+    
+    if (WiFi.status() == WL_CONNECTED) {
+        Serial.println("\nConectado a WiFi");
+        Serial.print("Dirección IP: ");
+        Serial.println(WiFi.localIP());
+    } else {
+        Serial.println("\nFalló la conexión WiFi");
+    }
+}
+
+// Función para leer sensor CNY70
 float leerCNY70() {
     const int NUMERO_MUESTRAS = 10;
     long suma = 0;
@@ -100,17 +122,143 @@ float leerCNY70() {
     return voltaje;
 }
 
+// Función para detectar contacto capacitivo
 bool detectarContacto() {
     int touchValue = touchRead(CAPACITIVO);
     return touchValue < 40; 
 }
 
+// Función para mostrar lectura en pantalla
+void mostrarLectura(float valor) {
+    tft.fillScreen(TFT_BLACK);
+    tft.setTextSize(2);
+    
+    // Mostrar título
+    tft.setCursor(10, 10);
+    tft.println("Resultado de lectura:");
+    
+    // Mostrar valor
+    tft.setCursor(10, 40);
+    tft.setTextSize(3);
+    tft.printf("%.2f V", valor);
+    
+    // Mostrar estado
+    tft.setTextSize(2);
+    tft.setCursor(10, 80);
+    tft.println("Estado: Completado");
+    
+    // Mostrar timestamp
+    tft.setCursor(10, 110);
+    tft.setTextSize(1);
+    unsigned long tiempoTranscurrido = millis() / 1000;
+    tft.printf("Tiempo: %02lu:%02lu:%02lu", 
+        tiempoTranscurrido / 3600,
+        (tiempoTranscurrido % 3600) / 60,
+        tiempoTranscurrido % 60
+    );
+}
 
+// Función para guardar medición en EEPROM
+void guardarMedicionEnEEPROM(unsigned long timestamp, int valor) {
+    if (writeIndex >= EEPROM_SIZE - sizeof(RegistroEstado)) {
+        writeIndex = 0;  // Volver al inicio si se llena
+    }
+    
+    RegistroEstado registro;
+    registro.enviado = false;
+    registro.timestamp = timestamp;
+    registro.valor = valor;
+    
+    EEPROM.put(writeIndex, registro);
+    
+    if (EEPROM.commit()) {
+        Serial.println("Datos guardados en EEPROM");
+        writeIndex += sizeof(RegistroEstado);
+    } else {
+        Serial.println("Error al guardar en EEPROM");
+    }
+}
+
+// Función para enviar datos al servidor
+void enviarDatosAlServidor() {
+    if (WiFi.status() != WL_CONNECTED) {
+        Serial.println("Sin conexión WiFi");
+        return;
+    }
+
+    HTTPClient http;
+    http.begin("http://192.168.0.10:5000/api/mediciones");
+    http.addHeader("Content-Type", "application/json");
+    
+    int registrosEnviados = 0;
+    
+    for (int i = 0; i < writeIndex; i += sizeof(RegistroEstado)) {
+        RegistroEstado registro;
+        EEPROM.get(i, registro);
+        
+        if (!registro.enviado) {
+            String jsonData = "{\"timestamp\":" + String(registro.timestamp) + 
+                            ",\"valor\":" + String(registro.valor/100.0, 2) + "}";
+            
+            int httpCode = http.POST(jsonData);
+            
+            if (httpCode == HTTP_CODE_OK || httpCode == HTTP_CODE_CREATED) {
+                registro.enviado = true;
+                EEPROM.put(i, registro);
+                registrosEnviados++;
+                Serial.printf("Registro enviado exitosamente. Timestamp: %lu\n", registro.timestamp);
+            } else {
+                Serial.printf("Error al enviar registro. HTTP code: %d\n", httpCode);
+                break;
+            }
+            delay(100);
+        }
+    }
+    
+    http.end();
+    
+    if (registrosEnviados > 0 && EEPROM.commit()) {
+        Serial.printf("Se marcaron %d registros como enviados\n", registrosEnviados);
+    } else {
+        Serial.println("Error al actualizar estado de registros en EEPROM");
+    }
+}
+
+// Función para entrar en modo bajo consumo
+void entrarModoBajoConsumo() {
+    Serial.println("Entrando en modo de bajo consumo...");
+    
+    // Apagar LEDs
+    digitalWrite(LED_ROJO, LOW);
+    digitalWrite(LED_VERDE, LOW);
+    
+    // Mostrar mensaje en pantalla
+    tft.fillScreen(TFT_BLACK);
+    tft.setTextSize(2);
+    tft.setCursor(10, 10);
+    tft.println("Modo de bajo consumo");
+    tft.setTextSize(1);
+    tft.setCursor(10, 40);
+    tft.println("Toque el sensor para");
+    tft.setCursor(10, 55);
+    tft.println("realizar nueva lectura");
+    
+    // Configurar despertar por touch
+    touchAttachInterrupt(CAPACITIVO, [](){}, 40);
+    esp_sleep_enable_touchpad_wakeup();
+    
+    delay(2000);
+    esp_deep_sleep_start();
+}
+
+// Bucle principal
 void loop() {
     unsigned long currentTime = millis();
     bool contactoDetectado = detectarContacto();
     
-    Serial.printf("Touch Value: %d, Contacto: %s\n", touchRead(CAPACITIVO), contactoDetectado ? "SI" : "NO");
+    Serial.printf("Valor Touch: %d, Contacto: %s\n", 
+                 touchRead(CAPACITIVO), 
+                 contactoDetectado ? "SI" : "NO");
     
     if (contactoDetectado && !leyendo) {
         leyendo = true;
@@ -160,69 +308,5 @@ void loop() {
             digitalWrite(LED_ROJO, !digitalRead(LED_ROJO));
             lastBlinkTime = currentTime;
         }
-    }
-}
-
-void guardarMedicionEnEEPROM(unsigned long timestamp, int valor) {
-    if (writeIndex >= EEPROM_SIZE - sizeof(RegistroEstado)) {
-        writeIndex = 0;  
-    }
-    
-    RegistroEstado registro;
-    registro.enviado = false;
-    registro.timestamp = timestamp;
-    registro.valor = valor;
-    
-    EEPROM.put(writeIndex, registro);
-    
-    if (EEPROM.commit()) {
-        Serial.println("Datos guardados en EEPROM");
-        writeIndex += sizeof(RegistroEstado);
-    } else {
-        Serial.println("Error al guardar en EEPROM");
-    }
-}
-
-void enviarDatosAlServidor() {
-    if (WiFi.status() != WL_CONNECTED) {
-        Serial.println("Sin conexión WiFi");
-        return;
-    }
-
-    HTTPClient http;
-    http.begin("http://192.168.0.10:5000/api/mediciones");
-    http.addHeader("Content-Type", "application/json");
-    
-    int registrosEnviados = 0;
-    
-    for (int i = 0; i < writeIndex; i += sizeof(RegistroEstado)) {
-        RegistroEstado registro;
-        EEPROM.get(i, registro);
-        
-        if (!registro.enviado) {
-            String jsonData = "{\"timestamp\":" + String(registro.timestamp) + 
-                            ",\"valor\":" + String(registro.valor/100.0, 2) + "}";
-            
-            int httpCode = http.POST(jsonData);
-            
-            if (httpCode == HTTP_CODE_OK || httpCode == HTTP_CODE_CREATED) {
-                registro.enviado = true;
-                EEPROM.put(i, registro);
-                registrosEnviados++;
-                Serial.printf("Registro enviado exitosamente. Timestamp: %lu\n", registro.timestamp);
-            } else {
-                Serial.printf("Error al enviar registro. HTTP code: %d\n", httpCode);
-                break;
-            }
-            delay(100);
-        }
-    }
-    
-    http.end();
-    
-    if (registrosEnviados > 0 && EEPROM.commit()) {
-        Serial.printf("Se marcaron %d registros como enviados\n", registrosEnviados);
-    } else {
-        Serial.println("Error al actualizar estado de registros en EEPROM");
     }
 }

--- a/C prototipo/integracion Pi/test/README
+++ b/C prototipo/integracion Pi/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
Conecta el ESP32 al WiFi para mandar datos
Lee un sensor CNY70 para medir reflejos de luz
Guarda todo en la memoria por si falla algo
Muestra los resultados en una pantalla TFT
Avisa con luces LED cuando está funcionando
Toma medidas cuando tocas el sensor
Parpadea una luz verde mientras mide
Guarda los datos y los manda por WiFi
Si no hay WiFi, los guarda para mandarlos después
Se duerme para ahorrar batería cuando termina
Muestra en la pantalla los valores que va midiendo
Te avisa si hay problemas con una luz roja
Se despierta cuando lo tocas para hacer nuevas medidas
Manda todo a un servidor